### PR TITLE
Fix script example in Installation section(Step 5)

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -68,7 +68,7 @@ Installation
 
    .. code-block:: shell
 
-        python -m lmp.script.sample_from_dataset --dset_name chinese-poem
+        python -m lmp.script.sample_from_dataset chinese-poem
 
 Training Pipline
 ----------------


### PR DESCRIPTION
`--dset_name` is a unrecognized arguments of `lmp.script.sample_from_dataset`.
The available arguments of `lmp.script.sample_from_dataset` is {chinese-poem, wikitext-2}